### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,26 +36,26 @@
   "homepage": "https://github.com/cilice/markdown-cli#readme",
   "preferGlobal": true,
   "dependencies": {
-    "cardinal": "^0.6.0",
-    "chalk": "^1.1.1",
+    "cardinal": "^1.0.0",
+    "chalk": "^2.1.0",
     "cli-table": "^0.3.1",
     "get-stdin": "^5.0.0",
-    "indent-string": "^2.1.0",
+    "indent-string": "3.2.0",
     "lodash.flow": "^3.2.1",
-    "lodash.trimleft": "^3.0.2",
-    "lodash.trimright": "^3.0.2",
-    "lodash.unescape": "^3.0.0",
+    "lodash.trimstart": "^4.0.0",
+    "lodash.trimend": "^4.0.0",
+    "lodash.unescape": "^4.0.0",
     "marked": "^0.3.5",
     "meow": "^3.4.2",
     "node-emoji": "^1.0.3",
-    "update-notifier": "^0.6.0",
-    "wrap-ansi": "^1.0.0"
+    "update-notifier": "^2.2.0",
+    "wrap-ansi": "^3.0.1"
   },
   "devDependencies": {
     "ava": "^0.7.0",
     "coveralls": "^2.11.4",
     "nyc": "^8.1.0",
-    "xo": "^0.11.1"
+    "xo": "^0.18.2"
   },
   "xo": {
     "esnext": true

--- a/renderer.js
+++ b/renderer.js
@@ -39,7 +39,7 @@ class Renderer {
 			utils.unescape,
 			utils.emoji,
 			text => utils.wrapAnsi(text, this.cli.width - (2 * level), {hard: this.cli.hard}),
-			text => utils.indentString(text, `${chalk.grey('|')} `, level),
+			text => utils.indentString(text, level, `${chalk.grey('|')} `),
 			utils.padding
 		);
 
@@ -76,7 +76,7 @@ class Renderer {
 		const flow = utils.compose(
 			utils.unescape,
 			utils.emoji,
-			text => utils.indentString(text, ` `, 2),
+			text => utils.indentString(text, 2, ' '),
 			text => text.replace(/\n+/g, '\n'),
 			text => utils.wrapList(text, this.cli.width, {hard: this.cli.hard}),
 			utils.padding

--- a/utils.js
+++ b/utils.js
@@ -6,8 +6,8 @@ const emoji = require('node-emoji');
 const cardinal = require('cardinal');
 const flow = require('lodash.flow');
 const unescape = require('lodash.unescape');
-const trimRight = require('lodash.trimright');
-const trimLeft = require('lodash.trimleft');
+const trimEnd = require('lodash.trimend');
+const trimStart = require('lodash.trimstart');
 const indentString = require('indent-string');
 const wrapAnsi = require('wrap-ansi');
 
@@ -23,10 +23,10 @@ module.exports = {
 	padding,
 	compose: flow,
 	emoji: insertEmojis,
-	indent: text => indentString(text, ' ', 2),
+	indent: text => indentString(text, 2, ' '),
 	indentString,
-	trimRight,
-	trimLeft,
+	trimEnd,
+	trimStart,
 	wrapLine: wrapAnsi,
 	wrapList: (text, cols, opts) => {
 		const input = text.split('\n');
@@ -38,10 +38,10 @@ module.exports = {
 				const level = (regex[0].length || 0);
 				const lineWidth = cols - level - 2;
 				const compose = flow(
-					line => trimLeft(line, regex[0]),
+					line => trimStart(line, regex[0]),
 					line => wrapAnsi(line, lineWidth, opts),
-					line => indentString(line, ' ', level),
-					line => trimLeft(line),
+					line => indentString(line, level, ' '),
+					line => trimStart(line),
 					line => `${regex[0]}${line}`
 				);
 


### PR DESCRIPTION
Heyo. 👋 

We're using `markdown-cli` in one our projects and npm warns about deprecated deps included in the project.

```
npm WARN deprecated lodash.trimleft@3.0.4: This package is discontinued. Use lodash.trimstart@^4.0.0.
npm WARN deprecated lodash.trimright@3.0.4: This package is discontinued. Use lodash.trimend@^4.0.0.
```

This PR aims to update the dependencies triggering the warnings. 

`npm test` and a check against the included `Readme.md` look good.

*Side note: This PR does not update a few of the dev dependencies as e.g. `nyc` jumped three majors and I didn't get the test to succeed quickly. :)*